### PR TITLE
Fix loading spinner placement and colour

### DIFF
--- a/src/components/loading-icon.ts
+++ b/src/components/loading-icon.ts
@@ -5,15 +5,23 @@ import { customElement } from "lit/decorators.js";
 export class MaptilerGeocodeLoadingIconElement extends LitElement {
   /** @internal */
   static styles = css`
+    :host {
+      display: flex;
+      align-items: center;
+      /* The host is wider than its container on purpose — it must not be squashed to fit. */
+      flex-shrink: 0;
+    }
+
     div {
-      position: absolute;
-      left: 50%;
-      top: 50%;
-      transform: translate(-50%, -50%);
       pointer-events: none;
 
       display: flex;
       align-items: center;
+    }
+
+    svg {
+      display: block;
+      fill: var(--color-icon-button, #444952);
     }
 
     .loading-icon {
@@ -36,7 +44,7 @@ export class MaptilerGeocodeLoadingIconElement extends LitElement {
     return html`
       <div>
         <svg viewBox="0 0 18 18" width="24" height="24" class="loading-icon">
-          <path fill="#333" d="M4.4 4.4l.8.8c2.1-2.1 5.5-2.1 7.6 0l.8-.8c-2.5-2.5-6.7-2.5-9.2 0z" />
+          <path d="M4.4 4.4l.8.8c2.1-2.1 5.5-2.1 7.6 0l.8-.8c-2.5-2.5-6.7-2.5-9.2 0z" />
           <path opacity=".1" d="M12.8 12.9c-2.1 2.1-5.5 2.1-7.6 0-2.1-2.1-2.1-5.5 0-7.7l-.8-.8c-2.5 2.5-2.5 6.7 0 9.2s6.6 2.5 9.2 0 2.5-6.6 0-9.2l-.8.8c2.2 2.1 2.2 5.6 0 7.7z" />
         </svg>
       </div>

--- a/src/geocoder/geocoder.css
+++ b/src/geocoder/geocoder.css
@@ -151,6 +151,8 @@ button:active {
   display: none;
   position: relative;
   align-items: stretch;
+  width: var(--size-clear-button-container, 13px);
+  justify-content: center;
 }
 .clear-button-container.displayable {
   display: flex;


### PR DESCRIPTION
Fixes #122

## Objective

The loading spinner is clipped by the search field and ignores the icon colour token.

## Description

While a geocoding request is in flight the spinner replaces the clear (✕) button. It was
the only icon in the control that was neither laid out nor themed like the rest:

- **Placement** — the spinner was absolutely positioned, so its host contributed no size
  and `.clear-button-container` collapsed to 0px wide. Centring 24px on a zero-width box at
  the padding edge pushed ~4px past the form, where `overflow: hidden` cut it off.
- **Colour** — `fill="#333"` was hardcoded, so the spinner was a different grey from the ✕
  it replaces, and overriding `--color-icon-button` had no effect during loading.

`.clear-button-container` is now pinned to the clear button's width (`--size-clear-button-container`, 13px) so the box survives the swap — while loading the spinner is that container's only child, which is what collapsed it. The spinner keeps its
24px size and overflows the 13px box symmetrically: its ink is a ring 17.3px across, and a rotating ring has a constant footprint, so it still lands ~5.3px clear of the field edge.

### Acceptance

The spinner now occupies the same visual position as the clear (✕) button it replaces: the same spacing from the right edge of the field, and the same optical centre. Swapping between the two states is invisible apart from the icon itself — nothing shifts, and nothing is cut off.