### PR TITLE
RD-2224 Add ::part() support for maptiler-geocoder

### DIFF
--- a/demos/08-bootstrap.html
+++ b/demos/08-bootstrap.html
@@ -16,8 +16,13 @@
         margin: 0.5rem;
       }
 
+      .first::part(feature-item__text-line-2) {
+        color: darkred;
+      }
+
       .second {
         --size-width: 300px;
+        --size-clear-button-container: auto;
         --input-group-padding: 0;
         --color-items: rebeccapurple;
         --color-items-secondary: violet;

--- a/src/geocoder/geocoder-feature-item.css
+++ b/src/geocoder/geocoder-feature-item.css
@@ -86,10 +86,10 @@ li > img {
     transform: translateX(0);
   }
   45% {
-    transform: translateX(calc(-100% + 270px));
+    transform: translateX(calc(-100% + var(--feature-item-animate-width, var(--size-width, 270px))));
   }
   55% {
-    transform: translateX(calc(-100% + 270px));
+    transform: translateX(calc(-100% + var(--feature-item-animate-width, var(--size-width, 270px))));
   }
   90% {
     transform: translateX(0);

--- a/src/geocoder/geocoder-feature-item.ts
+++ b/src/geocoder/geocoder-feature-item.ts
@@ -109,6 +109,7 @@ export class MaptilerGeocoderFeatureItemElement extends LitElement {
   render() {
     return html`
       <li
+        part="container ${this.itemStyle}"
         tabindex="-1"
         role="option"
         aria-selected=${this.itemStyle === "selected"}
@@ -119,6 +120,7 @@ export class MaptilerGeocoderFeatureItemElement extends LitElement {
         ${sprites && this.spriteIcon
           ? html`
               <div
+                part="icon sprite ${this.itemStyle}"
                 class="sprite-icon"
                 style=${styleMap({
                   width: `${this.spriteIcon.width / scaleFactor}px`,
@@ -131,24 +133,24 @@ export class MaptilerGeocoderFeatureItemElement extends LitElement {
               />
             `
           : this.imageUrl
-            ? html` <img src=${this.imageUrl} alt=${this.category} title=${this.#placeType} @error=${this.#handleImgError} />`
+            ? html` <img part="icon category ${this.itemStyle}" src=${this.imageUrl} alt=${this.category} title=${this.#placeType} @error=${this.#handleImgError} />`
             : this.feature?.address
-              ? html` <img src=${this.iconsBaseUrl + "housenumber.svg"} alt=${this.#placeType} title=${this.#placeType} /> `
+              ? html` <img part="icon address ${this.itemStyle}" src=${this.iconsBaseUrl + "housenumber.svg"} alt=${this.#placeType} title=${this.#placeType} /> `
               : this.feature?.id.startsWith("road.")
-                ? html` <img src=${this.iconsBaseUrl + "road.svg"} alt=${this.#placeType} title=${this.#placeType} /> `
+                ? html` <img part="icon road ${this.itemStyle}" src=${this.iconsBaseUrl + "road.svg"} alt=${this.#placeType} title=${this.#placeType} /> `
                 : this.feature?.id.startsWith("address.")
-                  ? html` <img src=${this.iconsBaseUrl + "street.svg"} alt=${this.#placeType} title=${this.#placeType} /> `
+                  ? html` <img part="icon street ${this.itemStyle}" src=${this.iconsBaseUrl + "street.svg"} alt=${this.#placeType} title=${this.#placeType} /> `
                   : this.feature?.id.startsWith("postal_code.")
-                    ? html` <img src=${this.iconsBaseUrl + "postal_code.svg"} alt=${this.#placeType} title=${this.#placeType} /> `
+                    ? html` <img part="icon postal-code ${this.itemStyle}" src=${this.iconsBaseUrl + "postal_code.svg"} alt=${this.#placeType} title=${this.#placeType} /> `
                     : this.feature?.id.startsWith("poi.")
-                      ? html` <img src=${this.iconsBaseUrl + "poi.svg"} alt=${this.#placeType} title=${this.#placeType} /> `
+                      ? html` <img part="icon poi ${this.itemStyle}" src=${this.iconsBaseUrl + "poi.svg"} alt=${this.#placeType} title=${this.#placeType} /> `
                       : this.#isReverse
-                        ? html` <img src=${this.iconsBaseUrl + "reverse.svg"} alt=${this.#placeType} title=${this.#placeType} /> `
-                        : html` <img src=${this.iconsBaseUrl + "area.svg"} alt=${this.#placeType} title=${this.#placeType} /> `}
+                        ? html` <img part="icon reverse ${this.itemStyle}" src=${this.iconsBaseUrl + "reverse.svg"} alt=${this.#placeType} title=${this.#placeType} /> `
+                        : html` <img part="icon area ${this.itemStyle}" src=${this.iconsBaseUrl + "area.svg"} alt=${this.#placeType} title=${this.#placeType} /> `}
 
-        <span class="texts">
-          <span>
-            <span class="primary"> ${this.#isReverse ? this.feature?.place_name : this.feature?.place_name.replace(/,.*/, "")} </span>
+        <span part="texts ${this.itemStyle}" class="texts">
+          <span part="text-line-1 ${this.itemStyle}">
+            <span part="text-primary ${this.itemStyle}" class="primary"> ${this.#isReverse ? this.feature?.place_name : this.feature?.place_name.replace(/,.*/, "")} </span>
 
             ${this.showPlaceType === "always" ||
             (this.showPlaceType !== "never" &&
@@ -158,11 +160,11 @@ export class MaptilerGeocoderFeatureItemElement extends LitElement {
               !this.feature?.id.startsWith("postal_code.") &&
               (!this.feature?.id.startsWith("poi.") || !this.imageUrl) &&
               !this.#isReverse)
-              ? html` <span class="secondary"> ${this.#placeType} </span> `
+              ? html` <span part="text-secondary ${this.itemStyle}" class="secondary"> ${this.#placeType} </span> `
               : nothing}
           </span>
 
-          <span class="line2"> ${this.#isReverse ? this.feature?.text : this.feature?.place_name.replace(/[^,]*,?s*/, "")} </span>
+          <span part="text-line-2 ${this.itemStyle}" class="line2"> ${this.#isReverse ? this.feature?.text : this.feature?.place_name.replace(/[^,]*,?s*/, "")} </span>
         </span>
       </li>
     `;

--- a/src/geocoder/geocoder.ts
+++ b/src/geocoder/geocoder.ts
@@ -735,6 +735,7 @@ export class MaptilerGeocoderElement extends LitElement implements MaptilerGeoco
     /* eslint-disable @typescript-eslint/unbound-method */
     return html`
       <form
+        part="container ${this.collapsed && this.searchValue === "" ? "can-collapse" : ""}"
         class=${classMap({ "can-collapse": this.collapsed && this.searchValue === "" })}
         @submit=${this.#handleSubmit}
         @focusin=${this.#handleFocusIn}
@@ -745,11 +746,11 @@ export class MaptilerGeocoderElement extends LitElement implements MaptilerGeoco
         @change=${this.#handleChange}
       >
         <slot name="content">
-          <div class="input-group">
+          <div part="input-group" class="input-group">
             <slot name="start"></slot>
 
             <slot name="search-button">
-              <button class="search-button" type="button">
+              <button part="search-button" class="search-button" type="button">
                 <slot name="search-icon">
                   <maptiler-geocode-search-icon></maptiler-geocode-search-icon>
                 </slot>
@@ -757,14 +758,14 @@ export class MaptilerGeocoderElement extends LitElement implements MaptilerGeoco
             </slot>
 
             <slot name="input">
-              <input placeholder=${this.placeholder ?? "Search"} aria-label=${this.placeholder ?? "Search"} />
+              <input part="input" placeholder=${this.placeholder ?? "Search"} aria-label=${this.placeholder ?? "Search"} />
             </slot>
 
             <div class="clear-button-container ${classMap({ displayable: this.searchValue !== "" })}">
               ${!this.isLoading
                 ? html`
                     <slot name="clear-button">
-                      <button type="button" title=${this.clearButtonTitle ?? "clear"}>
+                      <button part="clear-button" type="button" title=${this.clearButtonTitle ?? "clear"}>
                         <slot name="clear-icon">
                           <maptiler-geocode-clear-icon></maptiler-geocode-clear-icon>
                         </slot>
@@ -781,7 +782,12 @@ export class MaptilerGeocoderElement extends LitElement implements MaptilerGeoco
             ${this.enableReverse === "button"
               ? html`
                   <slot name="reverse-button">
-                    <button type="button" class=${classMap({ active: this.reverseActive })} title=${this.reverseButtonTitle ?? "toggle reverse geocoding"}>
+                    <button
+                      type="button"
+                      part="reverse-button ${this.reverseActive ? "active" : ""})}"
+                      class=${classMap({ active: this.reverseActive })}
+                      title=${this.reverseButtonTitle ?? "toggle reverse geocoding"}
+                    >
                       <slot name="reverse-icon">
                         <maptiler-geocode-reverse-geocoding-icon></maptiler-geocode-reverse-geocoding-icon>
                       </slot>
@@ -804,7 +810,7 @@ export class MaptilerGeocoderElement extends LitElement implements MaptilerGeoco
                 <div>${this.errorMessage ?? "Something went wrong…"}</div>
 
                 <slot name="clear-error-button">
-                  <button>
+                  <button part="clear-error-button">
                     <slot name="clear-error-icon">
                       <maptiler-geocode-clear-icon></maptiler-geocode-clear-icon>
                     </slot>
@@ -829,6 +835,7 @@ export class MaptilerGeocoderElement extends LitElement implements MaptilerGeoco
                 `
               : html`
                   <ul
+                    part="feature-list ${this.openListOnTop ? "open-on-top" : ""}"
                     class="options ${classMap({ "open-on-top": this.openListOnTop })}"
                     @pointerleave=${this.#handlePointerLeave}
                     @pointerdown=${this.#handlePointerDown}
@@ -841,6 +848,17 @@ export class MaptilerGeocoderElement extends LitElement implements MaptilerGeoco
                       (feature) => feature.id + (feature.address ? "," + feature.address : ""),
                       (feature, i) => html`
                         <maptiler-geocoder-feature-item
+                          exportparts="
+                            container:feature-item,
+                            icon:feature-item__icon,
+                            texts:feature-item__texts,
+                            text-line-1:feature-item__text-line-1,
+                            text-primary:feature-item__text-primary,
+                            text-secondary:feature-item__text-secondary,
+                            text-line-2:feature-item__text-line-2,
+                            selected, picked, default,
+                            sprite, category, address, road, street, postal-code, poi, reverse, area
+                          "
                           .feature=${feature}
                           .showPlaceType=${this.showPlaceType ?? "if-needed"}
                           itemStyle=${this.selectedItemIndex === i ? "selected" : this.picked?.id === feature.id ? "picked" : "default"}


### PR DESCRIPTION
## Objective

Add more external styling support by incorporating [`::part()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/::part) pseudoelement

## Description

`maptiler-geocoder` can now be used with `::part()` pseudoelement in these combinations (parts in brackets are optional to narrow targetting):
* `container [can-collapse]`
* `input-group`
* `search-button`
* `input`
* `clear-button`
* `reverse-button [active]`
* `clear-error-button`
* `feature-list [open-on-top]`
* `feature-item [selected/picked/default]`
* `feature-item__icon [selected/picked/default] [sprite/category/address/road/street/postal-code/poi/reverse/area]`
* `feature-item__texts [selected/picked/default]`
* `feature-item__text-line-1 [selected/picked/default]`
* `feature-item__text-primary [selected/picked/default]`
* `feature-item__text-secondary [selected/picked/default]`
* `feature-item__text-line-2 [selected/picked/default]`

Also fixes a small bug where changing width of component would not change width of container used for scrolling long text in feature list.

### Acceptance

Manual styling testing
